### PR TITLE
Moved budget estimation to account holder constructor

### DIFF
--- a/src/main/java/com/aviva/CarRecommendations/EstimateBudget.java
+++ b/src/main/java/com/aviva/CarRecommendations/EstimateBudget.java
@@ -13,13 +13,13 @@ public class EstimateBudget {
     /**
      * Return the yearly budget of an AccountHolder as a float
      *
-     * @param user the AccountHolder for which to generate the budget
+     * @param accountNumber the AccountHolder for which to generate the budget
      * @return float representing the AccountHolder's yearly budget.
      */
-    public float calculateYearlyBudget(AccountHolder user) {
+    public static float calculateYearlyBudget(String accountNumber) {
         // Get AccountHolder's deposits
         BankingDataProcess bdpInit = new BankingDataProcess();
-        ArrayList<Float> deposits = bdpInit.getDeposits(user.getAccountNumber());
+        ArrayList<Float> deposits = bdpInit.getDeposits(accountNumber);
 
         // Sum all deposits
         float yearlyIn = 0;
@@ -28,7 +28,7 @@ public class EstimateBudget {
         }
 
         // Get all withdrawals and sum them
-        ArrayList<Float> withdrawals = bdpInit.getWithdrawals(user.getAccountNumber());
+        ArrayList<Float> withdrawals = bdpInit.getWithdrawals(accountNumber);
         float yearlyOut = 0;
         for (float i : withdrawals) {
             yearlyOut += i;
@@ -36,15 +36,4 @@ public class EstimateBudget {
 
         return yearlyIn - yearlyOut;
     }
-
-    /**
-     * Return the monthly budget of an AccountHolder as a float
-     *
-     * @param user the AccountHolder for which to generate the budget
-     * @return float representing the AccountHolder's monthly budget.
-     */
-    public float calculateMonthlyBudget(AccountHolder user) {
-        return calculateYearlyBudget(user) / 12;
-    }
-
 }

--- a/src/main/java/com/aviva/CarRecommendations/InterestFilter.java
+++ b/src/main/java/com/aviva/CarRecommendations/InterestFilter.java
@@ -27,13 +27,6 @@ public class InterestFilter {
         BankingDataProcess bdpInit = new BankingDataProcess();
         AccountHolder user = bdpInit.makeAccountHolder(accountNumber);
 
-        // Get and set the AccountHolder's budget
-        EstimateBudget ebInit = new EstimateBudget();
-        float yearlyBudget = ebInit.calculateYearlyBudget(user);
-        user.setSavings(yearlyBudget);
-        float monthlyBudget = ebInit.calculateMonthlyBudget(user);
-        user.setMonthlyBudget(monthlyBudget);
-
         // Get the list of possible cars for the AccountHolder
         BudgetFilter bfInit = new BudgetFilter();
         ArrayList<Car> cars = bfInit.getRecommendedCars(user);

--- a/src/main/java/com/aviva/Entities/AccountHolder.java
+++ b/src/main/java/com/aviva/Entities/AccountHolder.java
@@ -2,18 +2,22 @@ package com.aviva.Entities;
 
 // TODO: When this entity changes, change the budget estimation calculations accordingly
 
+import com.aviva.CarRecommendations.EstimateBudget;
+
 /**
  * This class represents an account holder at the bank
  */
 
 public class AccountHolder {
-    private String accountNumber;
+    private final String accountNumber;
     private int creditScore;
     private float savings;
     private float monthlyBudget;
 
     public AccountHolder(String accountNumber){
         this.accountNumber = accountNumber;
+        this.savings = EstimateBudget.calculateYearlyBudget(this.accountNumber);
+        this.monthlyBudget = this.savings / 12;
     }
 
     public void setCreditScore(int creditScore) {this.creditScore = creditScore;}

--- a/src/test/java/CarRecommendationsTest/EstimateBudgetTest.java
+++ b/src/test/java/CarRecommendationsTest/EstimateBudgetTest.java
@@ -8,22 +8,15 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EstimateBudgetTest {
-    EstimateBudget classToTest;
     AccountHolder knownAccount;
 
     @BeforeEach
     public void setup() {
-        classToTest = new EstimateBudget();
         knownAccount = new AccountHolder("1402110922112412");
     }
 
     @Test
     public void testCalculateYearlyBudget() {
-        assertEquals(38460.0F, classToTest.calculateYearlyBudget(knownAccount));
-    }
-
-    @Test
-    public void testCalculateMonthlyBudget() {
-        assertEquals(3205.0F, classToTest.calculateMonthlyBudget(knownAccount));
+        assertEquals(38460.0F, EstimateBudget.calculateYearlyBudget(knownAccount.getAccountNumber()));
     }
 }


### PR DESCRIPTION
<!--- Summarize your change in the title -->
<!--- Unless you are ready to merge it in, make this a draft. -->

## Context

<!--- Why did we make this change? What is the current implementation? -->
Currently we were initialising and calling the budget estimation method every time we ever created a new instance of account holder.
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Related to issue #42 

## Your Changes

**Description**:
<!--- Describe your changes here, in enough detail that anyone can understand what you did -->

I moved that method into the construction of an account holder, made it static as it seemed to make more sense here, and removed the areas where the budget estimation was being initialised in other parts of the code.

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (changing code structure only)
- [x] Breaking change (changing code functionality)

## Testing

<!--- Please describe in detail how you tested this pull request, even if its just how to run it. -->
Ran the automated tests and everything worked as before.

## Checklist

- [x] Code is up to date with main branch (no merge conflicts)
- [x] Code has been properly tested
- [x] Code has been properly documented
- [ ] One or two people have reviewed this pull request <!-- check this after making the PR -->
